### PR TITLE
NAC fix

### DIFF
--- a/nalu/__init__.py
+++ b/nalu/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '0.0.2'
+__version__ = '0.0.3'
 
 from .core import *
 from .layers import *

--- a/nalu/core/nac_cell.py
+++ b/nalu/core/nac_cell.py
@@ -19,9 +19,9 @@ class NacCell(nn.Module):
         self.out_shape = out_shape
         self.W_ = Parameter(Tensor(out_shape, in_shape))
         self.M_ = Parameter(Tensor(out_shape, in_shape))
-        self.W = Parameter(tanh(self.W_) * sigmoid(self.M_))
         xavier_uniform_(self.W_), xavier_uniform_(self.M_)
         self.register_parameter('bias', None)
 
-    def forward(self, input):
-        return linear(input, self.W, self.bias)
+    def forward(self, input):        
+        W = tanh(self.W_) * sigmoid(self.M_)
+        return linear(input, W, self.bias)


### PR DESCRIPTION
The NacCell class has a bug in it that turns it into a simple linear cell. The way it's written right now, the W_ and M_ are not updated and the tanh and sigmoid don't do anything.

I go into more detail in this notebook: https://github.com/vrxacs/NALU/blob/master/fauxNAC.ipynb